### PR TITLE
VirtualSSD Read 기능 구현

### DIFF
--- a/virtual_ssd_pkg/ssd.py
+++ b/virtual_ssd_pkg/ssd.py
@@ -1,6 +1,10 @@
+from .file_io import FileIO
+
+
 class VirtualSSD:
     def __init__(self):
-        pass
+        self.nand_file = 'nand.txt'
+        self.result_file = 'result.txt'
 
     def parsing_command(self, cmd):
         if type(cmd) != str:
@@ -15,7 +19,7 @@ class VirtualSSD:
             raise ValueError("INVALID COMMAND")
 
     def is_valid_write_command(self, cmd_list):
-        return len(cmd_list) == 4 and cmd_list[0:2] == ['ssd', 'W'] and\
+        return len(cmd_list) == 4 and cmd_list[0:2] == ['ssd', 'W'] and \
             self.valid_LBA(cmd_list[2]) and self.valid_value(cmd_list[3])
 
     def is_valid_read_command(self, cmd_list):
@@ -32,3 +36,16 @@ class VirtualSSD:
         if value.startswith('0x') and len(value) == 10:
             return True
         return False
+
+    def read(self, lba):
+        self.valid_LBA(lba)
+
+        nand_file_data = ['0x00000000' for _ in range(100)]
+        nand_file_io = FileIO(self.nand_file)
+        nand_file_data_raw = nand_file_io.load().strip().split('\n')
+
+        for i, line in enumerate(nand_file_data_raw):
+            nand_file_data[i] = line
+
+        with open(self.result_file, 'w') as f:
+            f.write(nand_file_data[int(lba)])

--- a/virtual_ssd_pkg/ssd.py
+++ b/virtual_ssd_pkg/ssd.py
@@ -50,7 +50,8 @@ class VirtualSSD:
         return False
 
     def read(self, lba):
-        self.valid_LBA(lba)
+        if not self.valid_LBA(lba):
+            return
 
         nand_file_data = ['0x00000000' for _ in range(100)]
         nand_file_io = FileIO(self.nand_file)

--- a/virtual_ssd_pkg/test_virtual_ssd.py
+++ b/virtual_ssd_pkg/test_virtual_ssd.py
@@ -92,3 +92,12 @@ class TestVirtualSSD(TestCase):
 
         mock_file.assert_any_call('result.txt', 'w')  # 파일 쓰기도 mock 확인
         mock_file.return_value.write.assert_called_once_with(result_read)
+
+    @patch('builtins.open', new_callable=mock_open, read_data='0x00000000\n0x11111111\n0x22222222\n')
+    def test_virtual_ssd_read_with_mocked_file(self, mock_file):
+        self.virtual_ssd.read('1')
+        mock_file.assert_any_call('nand.txt', 'r')
+        mock_file.assert_any_call('result.txt', 'w')
+
+
+


### PR DESCRIPTION
VirtualSSD read 함수 구현 및 테스트 코드 입니다.

- read 함수 테스트 코드에서 validation은 따로 진행하지 않았습니다. (validation 코드 따로 존재)
- mock file (nand.txt라고 가정)을 사용하여 read 함수 test code 작성 시, 값을 return 하지 않고서는 result.txt write 검증이 불가능 하였습니다.
- 따라서, mock_file.assert_any_call 사용하여 'nand.txt' 와 'result.txt' 호출이 되는지 테스트 하였습니다.
