### PR TITLE
ssd.py runtime error 수정 및 ssd read test code 수정

### DIFF
--- a/virtual_ssd_pkg/command.py
+++ b/virtual_ssd_pkg/command.py
@@ -56,7 +56,7 @@ class WriteCommand(Command):
 class ReadCommand(Command):
     def execute(self, args):
         if self.is_invalid_lba(args[1]):
-            raise ValueError(INVALID_COMMAND)
+            raise Exception(INVALID_COMMAND)
 
         nand_file_data = ['0x00000000' for _ in range(100)]
         nand_file_io = FileIO(self.nand_file)

--- a/virtual_ssd_pkg/ssd.py
+++ b/virtual_ssd_pkg/ssd.py
@@ -2,6 +2,8 @@ import sys
 
 from command import InvalidCommand, WriteCommand, ReadCommand
 
+INVALID_COMMAND = "INVALID COMMAND"
+
 
 class VirtualSSD:
     def __init__(self):
@@ -25,4 +27,7 @@ class VirtualSSD:
 
 if __name__ == '__main__':
     ssd = VirtualSSD()
-    ssd.run()
+    try:
+        ssd.run()
+    except Exception:
+        print(INVALID_COMMAND)

--- a/virtual_ssd_pkg/test_command.py
+++ b/virtual_ssd_pkg/test_command.py
@@ -68,16 +68,16 @@ class TestReadCommand(TestCase):
         mock_file.assert_any_call('result.txt', 'w')
 
     def test_execute_lba_not_int_type(self):
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaises(Exception) as context:
             self.executor.execute([None, 'T'])
 
     def test_execute_lba_not_string_int_type(self):
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaises(Exception) as context:
             self.executor.execute([None, 1])
 
     def test_execute_lba_out_of_range(self):
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaises(Exception) as context:
             self.executor.execute([None, '-1'])
 
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaises(Exception) as context:
             self.executor.execute([None, '100'])

--- a/virtual_ssd_pkg/test_virtual_ssd.py
+++ b/virtual_ssd_pkg/test_virtual_ssd.py
@@ -1,34 +1,34 @@
 import os
+import subprocess
 from unittest import TestCase
 from unittest.mock import patch
 
-from virtual_ssd_pkg.ssd import VirtualSSD
+from ssd import VirtualSSD
+from file_io import FileIO
 
+INVALID_COMMAND = "INVALID COMMAND"
 
 class TestVirtualSSD(TestCase):
     def setUp(self):
         self.virtual_ssd = VirtualSSD()
 
-    @patch('os.system')
-    def test_cli_invalid_command(self, mock_system):
-        mock_system.return_value = 1
-        result = os.system('python ssd.py A')
-        self.assertEqual(result, 1)
+    def test_cli_invalid_command(self):
+        result = subprocess.run(['python', 'ssd.py', 'A'], capture_output=True, text=True)
+        self.assertIn(INVALID_COMMAND, result.stdout)
 
-    @patch('os.system')
-    def test_read_with_cli(self, mock_system):
-        mock_system.return_value = 0
-        result = os.system('python ssd.py R 1')
-        self.assertEqual(result, 0)
+    def test_read_with_cli(self):
+        result = subprocess.run(['python', 'ssd.py', 'R', '1'], capture_output=True, text=True)
+        self.assertIn('', result.stdout)
+        file_io = FileIO('result.txt')
+        ret = file_io.load()
+        self.assertEqual(ret, '0x00000000')
 
-    @patch('os.system')
-    def test_read_with_cli_invalid_lba_range(self, mock_system):
-        mock_system.return_value = 1
-        result = os.system('python ssd.py R -1')
-        self.assertEqual(result, 1)
+    def test_read_with_cli_invalid_lba_range(self):
+        result = subprocess.run(['python', 'ssd.py', 'R', '-1'], capture_output=True, text=True)
+        self.assertIn(INVALID_COMMAND, result.stdout)
 
-        result = os.system('python ssd.py R 100')
-        self.assertEqual(result, 1)
+        result = subprocess.run(['python', 'ssd.py', 'R', '100'], capture_output=True, text=True)
+        self.assertIn(INVALID_COMMAND, result.stdout)
 
     @patch('os.system')
     def test_write_with_cli(self, mock_system):


### PR DESCRIPTION
- ssd.py runtime erorr 발생하는 부분을 print로 대체
- 기존 patch os.system을 사용하여 read 함수 test 하는 버그 수정하였습니다.