### PR TITLE
write test 및 기능 오류 수정 (긴 길이의 args 입력 제한 및 최초 file 생성 관련)

### DIFF
--- a/virtual_ssd_pkg/command.py
+++ b/virtual_ssd_pkg/command.py
@@ -34,7 +34,7 @@ class Command(ABC):
 
 class WriteCommand(Command):
     def is_invalid_parameter(self, args):
-        if len(args) < 3:
+        if len(args) != 3:
             return True
         if self.is_invalid_lba(args[1]):
             return True
@@ -55,6 +55,8 @@ class WriteCommand(Command):
 
 class ReadCommand(Command):
     def execute(self, args):
+        if len(args) != 2:
+            raise Exception(INVALID_COMMAND)
         if self.is_invalid_lba(args[1]):
             raise Exception(INVALID_COMMAND)
 

--- a/virtual_ssd_pkg/ssd.py
+++ b/virtual_ssd_pkg/ssd.py
@@ -7,7 +7,9 @@ INVALID_COMMAND = "INVALID COMMAND"
 
 class VirtualSSD:
     def __init__(self):
-        pass
+        for filename in ['result.txt','nand.txt']:
+            file = open(filename,'w')
+            file.write("")
 
     def run(self):
         args = sys.argv[1:]


### PR DESCRIPTION
VirtualSSD class의 write test를 추가하였습니다.
긴 길이의 args를 입력으로 받을 때, 입력을 제한하도록 설정하였습니다.
최초 실행(VirtualSSD class 호출)  시nand.txt와 result.txt 파일을 빈 파일로 만들도록 기능 추가하였습니다.